### PR TITLE
[FIXED #83837394] Removed deprecation warning during grunt build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ doc/
 nbproject/
 local-config.js
 npm-debug.log
+.idea

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -202,8 +202,7 @@ module.exports = function(grunt) {
 		sass: {
 			compile: {
 				options: {
-					unixNewlines: true,
-					sourcemap: true
+					unixNewlines: true
 				},
 				files: [{
 					expand: true,
@@ -215,8 +214,7 @@ module.exports = function(grunt) {
 			},
 			bootstrap: {
 				options: {
-					unixNewlines: true,
-					sourcemap: true
+					unixNewlines: true
 				},
 				files: [{
 					expand: true,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "*",
     "grunt-contrib-copy": "*",
-    "grunt-contrib-sass": "^0.7.3",
+    "grunt-contrib-sass": "^0.8.1",
     "grunt-contrib-watch": "*",
     "grunt-env": "^0.4.1",
     "grunt-mocha-test": "*",
@@ -36,7 +36,6 @@
     "object-hash": "~0.3.0"
   },
   "devDependencies": {
-    "grunt-contrib-sass": "^0.7.3",
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-contrib-yuidoc": "^0.5.2",
     "grunt-mocha-istanbul": "^2.1.0"


### PR DESCRIPTION
- upgraded grunt-contrib-sass to 0.8.1 which fixes wrong command line arguments: _--sourcemap=auto_ instead _--sourcemap auto_
- removed unnecessary sourcemap option - grunt-contrib-sass generates sourcesmaps by default
- removed "grunt-contrib-sass" from **devDependencies** - there is no need to place it there if it is already in **depedencies**
