### PR TITLE
[FIXED #97535084] Calendar expands incorrectly.

### DIFF
--- a/src/client/js/xpsui/directives/calendar.js
+++ b/src/client/js/xpsui/directives/calendar.js
@@ -56,7 +56,6 @@
 
 				if (value) {
 					self.setValue(value);
-					self.render();
 				}
 			});
 			


### PR DESCRIPTION
When tab was used to leave a filled date input, the calendar displayed,
moved all below elements further below and could not be closed.
Now the calendar does not open on tab leaving the input.
Calendar only displays on the calendar button.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sosik/registries/103)
<!-- Reviewable:end -->
